### PR TITLE
Add spread test for the IIO interface

### DIFF
--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -43,7 +43,7 @@ func (iface *IioInterface) String() string {
 // Pattern to match allowed iio device nodes. It is gonna be used to check the
 // validity of the path attributes in case the udev is not used for
 // identification
-var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio-device[0-9]")
+var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]")
 
 // Check validity of the defined slot
 func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -131,13 +131,16 @@ setup_reflash_magic() {
         # unpack our freshly build snapd into the new core snap
         dpkg-deb -x ${SPREAD_PATH}/../snapd_*.deb $UNPACKD
 
-        # add a gpio slot
+        # add gpio and iio slots
         cat >> $UNPACKD/meta/snap.yaml <<-EOF
 slots:
     gpio-pin:
         interface: gpio
         number: 100
         direction: out
+    iio0:
+        interface: iio
+        path: /dev/iio:device0
 EOF
 
         # build new core snap for the image
@@ -207,6 +210,7 @@ EOF
 StartLimitInterval=0
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAP_REEXEC=0
+ExecPreStart=/bin/touch /dev/iio:device0
 EOF
         mkdir -p /mnt/system-data/etc/systemd/system/snapd.socket.d
         cat <<EOF > /mnt/system-data/etc/systemd/system/snapd.socket.d/local.conf

--- a/tests/lib/snaps/iio-consumer/bin/read
+++ b/tests/lib/snaps/iio-consumer/bin/read
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat /dev/iio:device0

--- a/tests/lib/snaps/iio-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/iio-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: iio-consumer
+version: 1.0
+summary: Basic iio consumer snap
+description: A basic snap declaring a plug on a iio slot
+
+apps:
+  read:
+    command: bin/read
+    plugs: [iio]

--- a/tests/main/interfaces-iio/task.yaml
+++ b/tests/main/interfaces-iio/task.yaml
@@ -1,0 +1,46 @@
+summary: Check that IIO device nodes are accessible through an interface
+
+details: |
+    This test makes sure that the a snap using the IIO interface can access
+    devices nodes exposed by a slot properly.
+
+    It modifies the core snap to provide a iio slot. The actual iio device
+    node is served as a plain file with static text content. The test expects
+    that, after a snap declared a iio plug is installed and connected, it can
+    access the node and read/write its content.
+
+systems: [ubuntu-core-16-64]
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # Mock IIO device node and give it some content we can verify
+    # the test snap can read.
+    echo "iio-0" > /dev/iio:device0
+
+    echo "Given a snap declaring a plug on iio is installed"
+    . $TESTSLIB/snaps.sh
+    install_local iio-consumer
+
+    echo "And the iio plug is connected"
+    . "$TESTSLIB/names.sh"
+    snap connect iio-consumer:iio ${core_name}:iio0
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    rm /dev/iio:device0
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    test "`/snap/bin/iio-consumer.read`" = "iio-0"
+
+    # FIXME also test write access


### PR DESCRIPTION
Just tests the read side of it but adding the write part should be pretty easy.

Following HACKING.md to get qemu setup for spread locally and then run tests via
```
$ spread qemu:tests/main/interfaces-iio
```